### PR TITLE
Instruct to fully restart the terminal

### DIFF
--- a/book/src/tooling-check.md
+++ b/book/src/tooling-check.md
@@ -2,6 +2,7 @@
 
 ## Setup check
 
+✅ Fully restart your terminal (not just open a fresh tab).
 ✅ Let's check that you have installed Rust.
 
 ```console


### PR DESCRIPTION
Some operating systems cache the environment and don't pick up tools like wasmtime